### PR TITLE
fix: 修复设置重置问题并优化设置界面

### DIFF
--- a/.trae/specs/fix-settings-overwrite-and-polish-ui/checklist.md
+++ b/.trae/specs/fix-settings-overwrite-and-polish-ui/checklist.md
@@ -1,0 +1,12 @@
+# Checklist
+
+- [ ] `SettingsWindow` 构造期间(`InitializeComponent()` + `InitializeValues()`),不存在任何写 `ConfigManager` 或触发 `DebouncedSave()` 的代码路径
+- [ ] 按 Issue #16 复现步骤走查:修改延迟启动值 → 退出 → 重开,代码路径上滑块显示 config.json 中的值而非 150
+- [ ] 所有 XAML 订阅的 ValueChanged/IsOnChanged 处理器均有 `_isInitializing` 保护或等效保护
+- [ ] `InitializeValues()` 显式设置全部 UI 状态(面板显隐、状态文本、数值文本),不依赖处理器副作用
+- [ ] 初始化完成后,用户拖动滑块/切换开关,配置正常更新并保存,数值文本同步刷新
+- [ ] UI 改动仅限视觉属性(颜色/间距/圆角/阴影/字号),无控件增删、无 `x:Name` 变更、无事件订阅变更
+- [ ] 深色与浅色主题下设置页文本对比度充足、配色一致
+- [ ] 处理器样板整理后,每个处理器的目标配置字段、取值转换、文本格式化与原逻辑逐一对应
+- [ ] `Core/` 目录、`App.xaml.cs` 零改动
+- [ ] 所有改动的 XAML 文件通过 XML 良构性校验

--- a/.trae/specs/fix-settings-overwrite-and-polish-ui/spec.md
+++ b/.trae/specs/fix-settings-overwrite-and-polish-ui/spec.md
@@ -1,0 +1,48 @@
+# 修复设置值初始化覆盖 Bug 及 UI 视觉打磨 Spec
+
+## Why
+GitHub Issue #16 报告"延迟启动"的值在重启应用后被重置为默认值 150。根因是 `SettingsWindow` 构造函数中 `InitializeComponent()` 解析 XAML 时会触发各 Slider/Toggle 的 `ValueChanged`/`IsOnChanged` 处理器,把 XAML 设计默认值写入 `ConfigManager` 并 `DebouncedSave()`,早于 `InitializeValues()` 读取真实配置——这是一个影响多个设置项的 bug 类别,不止延迟启动。同时用户反馈 UI 界面不够美观,希望在零风险前提下做视觉打磨与代码整理。
+
+## What Changes
+- **Bug 修复(Issue #16 及同类)**:在 `SettingsWindow` 引入 `_isInitializing` 初始化保护标志;所有在 XAML 中订阅、且会写 `ConfigManager` 的事件处理器,在初始化期间直接返回,不再用 XAML 默认值覆盖用户配置。
+- **初始化路径审计**:确保 `_isInitializing` 保护生效后,`InitializeValues()` 显式完成所有必要的 UI 状态设置(面板显隐、状态文本、数值文本等),不依赖事件处理器的副作用。
+- **UI 保守视觉打磨**:不改布局结构与交互,只调整视觉层面——间距节奏、字体层级、圆角与阴影一致性、深浅主题配色一致性。
+- **代码顺带整理**:仅在本次修改触及的 `SettingsWindow.xaml.cs` 内,统一滑块处理器的样板模式(保护判断 + 写配置 + 更新数值文本 + 防抖保存),不改公共行为与架构。
+- 无 **BREAKING** 变更;除上述 bug 修复外,所有运行时行为保持不变。
+
+## Impact
+- Affected specs: 设置窗口(显示与持久化)、主题样式
+- Affected code:
+  - `UI/SettingsWindow.xaml.cs`(初始化保护、处理器整理)
+  - `UI/SettingsWindow.xaml`(仅间距/字体等视觉属性微调)
+  - `Themes/Generic.xaml`、`Themes/Light.xaml`、`Themes/Dark.xaml`(视觉 token 统一)
+- 明确不动:`Core/` 下所有滚动引擎与钩子逻辑、`App.xaml.cs`、Overlay/Update/Splash 窗口的交互行为。
+
+## ADDED Requirements
+### Requirement: 设置值初始化保护
+系统 SHALL 保证设置窗口打开(构造)过程中,任何控件的事件处理器都不得将 XAML 设计时默认值写入 `ConfigManager` 或触发配置保存;窗口完成初始化后,各控件显示的数值 SHALL 与 `config.json` 中持久化的值一致。
+
+#### Scenario: 延迟启动值重启后保持(对应 Issue #16)
+- **GIVEN** 用户已将延迟启动设置为非默认值(如 200ms)并正常退出应用
+- **WHEN** 用户再次启动应用并打开设置窗口
+- **THEN** 延迟启动滑块与数值文本显示 200ms,且 `config.json` 中的值不被改写
+
+#### Scenario: 其他设置项同类保护
+- **GIVEN** 用户修改过任意滑块设置(摩擦、惯量、阅读速度、曲线参数等)并退出
+- **WHEN** 再次打开设置窗口
+- **THEN** 所有设置项显示用户保存的值,无一项被重置为 XAML 默认值
+
+#### Scenario: 修改设置仍正常保存
+- **WHEN** 初始化完成后用户拖动任意滑块或切换开关
+- **THEN** 对应配置值正常更新并防抖保存到 `config.json`,数值文本同步刷新
+
+## MODIFIED Requirements
+### Requirement: 设置窗口视觉呈现
+设置窗口 SHALL 在不改变现有布局结构与交互方式的前提下,呈现统一的视觉规范:一致的卡片间距节奏、清晰的三级字体层级(分区标题/设置项标签/辅助说明)、统一的圆角与阴影,且深色与浅色主题下同一界面的对比度与观感一致、无错位或违和配色。
+
+#### Scenario: 深浅主题一致性
+- **WHEN** 用户在深色与浅色主题间切换并浏览设置窗口各分区
+- **THEN** 文本可读、对比度充足,控件无明显视觉异常
+
+## REMOVED Requirements
+无。

--- a/.trae/specs/fix-settings-overwrite-and-polish-ui/tasks.md
+++ b/.trae/specs/fix-settings-overwrite-and-polish-ui/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+- [ ] Task 1: 修复设置窗口初始化覆盖配置的 bug(对应 GitHub Issue #16 及同类问题)
+  - [ ] SubTask 1.1: 在 `UI/SettingsWindow.xaml.cs` 构造函数中引入 `_isInitializing` 标志:`InitializeComponent()` 前置为 true,`InitializeValues()` 完成后置为 false
+  - [ ] SubTask 1.2: 审计所有在 XAML 中订阅的 `ValueChanged`/`IsOnChanged` 等会写 `ConfigManager` 的处理器,在入口处加 `if (_isInitializing) return;` 保护(重点:MiddleClickDelaySlider、FrictionSlider、ReadingSpeedSlider、曲线参数滑块、各 ToggleSwitch)
+  - [ ] SubTask 1.3: 审计 `InitializeValues()`,确认保护生效后所有 UI 状态(面板显隐、状态文本、数值文本)均由初始化代码显式设置,不依赖处理器副作用;缺失的补齐
+  - [ ] SubTask 1.4: 静态验证:通读 diff,确认初始化期间无任何路径写配置或触发 `DebouncedSave()`,初始化后用户操作路径行为不变
+
+- [ ] Task 2: UI 保守视觉打磨(不改布局结构与交互)
+  - [ ] SubTask 2.1: 统一 `Themes/Generic.xaml` 中卡片圆角、阴影、内边距的取值,消除相近但不一致的数值
+  - [ ] SubTask 2.2: 梳理 `UI/SettingsWindow.xaml` 的 Margin/Padding 节奏与字体层级(分区标题/标签/说明三级),统一间距刻度
+  - [ ] SubTask 2.3: 校验 `Themes/Light.xaml` 与 `Themes/Dark.xaml` 配色:文本对比度、Accent 一致性,修正违和颜色
+  - [ ] SubTask 2.4: 复查所有视觉改动,确认未移动/删除任何控件、未改动任何事件订阅与名称
+
+- [ ] Task 3: `SettingsWindow.xaml.cs` 内滑块处理器样板代码整理
+  - [ ] SubTask 3.1: 将"初始化保护 + 写配置 + 更新数值文本 + 防抖保存"的重复模式提取为私有辅助方法
+  - [ ] SubTask 3.2: 逐个处理器迁移到辅助方法,核对每个处理器的取值/格式化/目标配置字段与原逻辑完全一致
+
+- [ ] Task 4: 整体验证
+  - [ ] SubTask 4.1: 用 XML 解析器校验所有改动的 `.xaml` 文件良构性
+  - [ ] SubTask 4.2: 全量 diff 审查:确认除 bug 修复与视觉 token 外无行为变化,`Core/` 未被改动
+  - [ ] SubTask 4.3: 对照 GitHub Issue #16 复现步骤做代码级走查,确认修复闭环
+
+# Task Dependencies
+- [Task 3] depends on [Task 1](保护标志需在处理器整理前先就位)
+- [Task 2] 与 [Task 1]/[Task 3] 无依赖,可并行
+- [Task 4] depends on [Task 1], [Task 2], [Task 3]


### PR DESCRIPTION
## 🎯 Changes

### 1. 修复设置值重启后被重置的 Bug
- 引入 `_isInitializing` 标志，在 `InitializeComponent()` 前设置为 `true`，在 `InitializeValues()` 后设置为 `false`。
- 为所有写入 `ConfigManager` 的滑块、开关、下拉框、单选按钮事件处理器添加初始化保护，防止在初始化期间写入配置。
- 在 `InitializeValues()` 中显式设置各数值文本，不再依赖事件处理器的副作用。

### 2. 设置窗口视觉打磨与统一
- 统一 `Themes/Generic.xaml` 中的卡片间距（`Margin` 从 10 调整为 12）和圆角取值（`CornerRadius` 从 5 调整为 6）。
- 调整分区标题字号（从 14 调整为 15）。
- 为滑块 `Thumb` 阴影补齐 `Direction="270"`，使投影方向一致。
- 统一 `UI/SettingsWindow.xaml` 中各按钮的 `Padding` 为 `8,4`、`Margin` 间距为 `8`，对齐间距刻度。
- 修正高级设置说明文本，改用 `Brush.Text.Secondary` 资源键。
- 调整版本徽标、支付标签、内容区域等的 `Margin` 和 `Padding`，统一视觉节奏。

### 3. 重构滑块处理器代码
- 提取 `UpdateSliderSetting` 通用辅助方法，统一“保护 + 写配置 + 更新文本 + 防抖保存”的样板代码。
- 将十余个滑块处理器迁移至新的辅助方法，保持取值转换与格式化与原逻辑一致。

## 💡 Technical Highlights

- **初始化保护**: 通过 `_isInitializing` 标志，精确控制配置写入时机，避免 `InitializeComponent()` 阶段的副作用。
- **代码复用**: `UpdateSliderSetting` 辅助方法显著减少了重复代码，提高了可维护性。
- **视觉一致性**: 统一的间距、圆角和字体层级，提升了用户界面的整体美观度和专业性。
- **问题根源解决**: 针对 GitHub Issue #16 的根本原因（XAML 解析时触发事件处理器），提供了精确的解决方案。